### PR TITLE
Generate JAR Artifacts for Remote Build Validation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,7 +29,7 @@ jobs:
         run: ./ci/build.sh
         
       - name: Checksum Client Build
-        run: echo RuneLite.jar `sha256sum sha256sum /home/runner/work/runelite-but-you-can-save-your-password/runelite-but-you-can-save-your-password/runelite-client/target/*-shaded.jar | cut -d' ' -f1` 
+        run: echo RuneLite.jar `sha256sum /home/runner/work/runelite-but-you-can-save-your-password/runelite-but-you-can-save-your-password/runelite-client/target/*-shaded.jar | cut -d' ' -f1` 
         
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2.2.4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,10 +29,10 @@ jobs:
         run: ./ci/build.sh
         
       - name: Checksum Client Build
-        run: sha256sum /home/runner/work/runelite-but-you-can-save-your-password/runelite-but-you-can-save-your-password/runelite-client/target/*.jar
+        run: echo RuneLite.jar `sha256sum sha256sum /home/runner/work/runelite-but-you-can-save-your-password/runelite-but-you-can-save-your-password/runelite-client/target/*-shaded.jar | cut -d' ' -f1` 
         
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v2.2.4
         with:
           name: RuneLite.jar
-          path: /home/runner/work/runelite-but-you-can-save-your-password/runelite-but-you-can-save-your-password/runelite-client/target/*.jar
+          path: /home/runner/work/runelite-but-you-can-save-your-password/runelite-but-you-can-save-your-password/runelite-client/target/*-shaded.jar

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,3 +27,12 @@ jobs:
 
       - name: Build
         run: ./ci/build.sh
+        
+      - name: Checksum Client Build
+        run: sha256sum /home/runner/work/runelite-but-you-can-save-your-password/runelite-but-you-can-save-your-password/runelite-client/target/*.jar
+        
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: RuneLite.jar
+          path: /home/runner/work/runelite-but-you-can-save-your-password/runelite-but-you-can-save-your-password/runelite-client/target/*.jar


### PR DESCRIPTION
The project can now just built using GH Actions. Extra security because the built data is exactly what's on the GH repo.